### PR TITLE
Fix typo in README: Competetive -> Competitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ python scripts/extract_images.py input_file.mp4
 ## 🔧 Key Features
 
 - **Autoregressive Flow Architecture**: Novel combination of autoregressive models and normalizing flows
-- **High-Quality Generation**: Competetive FID scores and visual quality to State-of-the-art Diffusion Models
+- **High-Quality Generation**: Competitive FID scores and visual quality to State-of-the-art Diffusion Models
 - **Flexible Resolution**: Support for various aspect ratios and resolutions
 - **Efficient Training**: FSDP support for large-scale distributed training
 - **Fast Sampling**: Block-wise Jacobi iteration for accelerated inference


### PR DESCRIPTION
## Summary
Fix typo in the Key Features section of README.md: `Competetive` -> `Competitive`.

## Why this matters
Noticed while reading the project README. The "High-Quality Generation" bullet under Key Features misspells "Competitive" (compe**te**tive instead of compe**ti**tive). One-character correction, no code or behavior change.
